### PR TITLE
Fix wrong i18n key for localisation

### DIFF
--- a/static/assets/i18n/en.json
+++ b/static/assets/i18n/en.json
@@ -1,8 +1,8 @@
 {
     "error": {
-        "mqtt": "Sorry, there was a communication error with the Snips platform",
+        "mqtt": "Sorry, there was a communication error with the Snips platform.",
         "config": "Sorry, there was an error with your config file.",
-        "locale": "Sorry, there was an error with your language settings.",
+        "localisation": "Sorry, there was an error with your language settings.",
         "intentNotRecognized": "Sorry, I did not understand your request.",
         "APIResponse": "Sorry, there was an issue with the service provider.",
         "APIRequest": "Sorry, the service provider is unreachable.",

--- a/static/assets/i18n/fr.json
+++ b/static/assets/i18n/fr.json
@@ -1,8 +1,8 @@
 {
     "error": {
-        "mqtt": "Désolé, une erreur s'est produite lors de la communication avec la plateforme Snips",
+        "mqtt": "Désolé, une erreur s'est produite lors de la communication avec la plateforme Snips.",
         "config": "Désolé, une erreur s'est produite avec votre fichier de configuration.",
-        "locale": "Désolé, une erreur s'est produite avec vos paramètres de localisation.",
+        "localisation": "Désolé, une erreur s'est produite avec vos paramètres de localisation.",
         "intentNotRecognized": "Désolé, je n'ai pas compris votre requête.",
         "APIResponse": "Désolé, une erreur s'est produite avec le service distant.",
         "APIRequest": "Désolé, le service distant est injoignable.",


### PR DESCRIPTION
The i18n key corresponding to the localisation configuration error message was incorrect (`locale` -> `localisation`).